### PR TITLE
Fix critical Vulkan bugs in swapchain and descriptor set handling

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -112,7 +112,8 @@ add_library(imgui
     imgui/imgui.cpp       imgui/imgui_internal.h  imgui/examples/imgui_impl_glfw.h     imgui/imstb_truetype.h
     imgui/imgui_demo.cpp  imgui/imgui_widgets.cpp imgui/examples/imgui_impl_vulkan.cpp
     imgui/imgui_draw.cpp  imgui/imstb_rectpack.h  imgui/examples/imgui_impl_vulkan.h)
-target_include_directories(imgui PUBLIC imgui PRIVATE ${Vulkan_INCLUDE_DIR})
+target_include_directories(imgui PUBLIC imgui PRIVATE ${Vulkan_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/glfw/include)
+target_link_libraries(imgui PUBLIC glfw ${Vulkan_LIBRARIES})
 target_compile_definitions(imgui PUBLIC -DIMGUI_IMPL_API=)
 
 # linalg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10.0)
 project(meshoui VERSION 0.2.0)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(Vulkan REQUIRED)
 
 add_subdirectory(3rdparty)

--- a/examples/cave_walking/main.cpp
+++ b/examples/cave_walking/main.cpp
@@ -14,10 +14,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -335,7 +335,7 @@ int main(int argc, char** argv)
                 VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                 vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
             }
-            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
             if (scene)
             {
                 MoPushConstant pmv = {};
@@ -374,7 +374,7 @@ int main(int argc, char** argv)
                     VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                     vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
                 }
-                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
                 if (scene)
                 {
                     MoPushConstant pmv = {};
@@ -403,7 +403,7 @@ int main(int argc, char** argv)
         }
 
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -411,7 +411,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         if (scene)
         {
             MoPushConstant pmv = {};

--- a/examples/cube_imgui/main.cpp
+++ b/examples/cube_imgui/main.cpp
@@ -14,9 +14,9 @@
 #include "mo_swapchain.h"
 
 #include <algorithm>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -57,7 +57,7 @@ void moGUIDrawBegin()
     ImGui::NewFrame();
 }
 
-bool moGUIFileBrowser(std::experimental::filesystem::path *pCurrentDirectory, std::experimental::filesystem::path *pFileToLoad, const std::vector<std::string>& allowedExtensions = {})
+bool moGUIFileBrowser(path *pCurrentDirectory, path *pFileToLoad, const std::vector<std::string>& allowedExtensions = {})
 {
     if (!std::filesystem::equivalent(*pCurrentDirectory, *pCurrentDirectory / ".."))
     {
@@ -237,7 +237,7 @@ int main(int argc, char** argv)
         VkSemaphore imageAcquiredSemaphore;
         moBeginSwapChain(swapChain, &currentCommandBuffer, &imageAcquiredSemaphore);
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moDrawMesh(currentCommandBuffer.buffer, cubeMesh);
 
         // ImGui

--- a/examples/cube_passthrough/main.cpp
+++ b/examples/cube_passthrough/main.cpp
@@ -10,14 +10,17 @@
 #include "mo_pipeline_utils.h"
 #include "mo_swapchain.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
 int main(int argc, char** argv)
 {
+    printf("[cube_passthrough] main() starting\n");
+    fflush(stdout);
+
     GLFWwindow*                  window = nullptr;
     VkInstance                   instance = VK_NULL_HANDLE;
     MoDevice                     device = VK_NULL_HANDLE;
@@ -27,8 +30,14 @@ int main(int argc, char** argv)
 
     // Initialization
     {
+        printf("[cube_passthrough] Initializing GLFW...\n");
+        fflush(stdout);
+
         glfwSetErrorCallback(moGlfwErrorCallback);
         glfwInit();
+
+        printf("[cube_passthrough] GLFW initialized\n");
+        fflush(stdout);
         int width, height;
         width = 1920 / 2;
         height = 1080 / 2;
@@ -64,6 +73,9 @@ int main(int argc, char** argv)
 
         // Create device
         {
+            printf("[cube_passthrough] About to create device...\n");
+            fflush(stdout);
+
             MoDeviceCreateInfo info = {};
             info.instance = instance;
             info.surface = surface;
@@ -73,46 +85,111 @@ int main(int argc, char** argv)
             info.requestColorSpace = VK_COLORSPACE_SRGB_NONLINEAR_KHR;
             info.pSurfaceFormat = &surfaceFormat;
             info.pCheckVkResultFn = moVkCheckResult;
+
+            printf("[cube_passthrough] Calling moCreateDevice...\n");
+            fflush(stdout);
+
             moCreateDevice(&info, &device);
+
+            printf("[cube_passthrough] Device created: %p\n", (void*)device);
+            fflush(stdout);
         }
 
         // Create SwapChain, RenderPass, Framebuffer, etc.
         {
+            printf("[cube_passthrough] About to create swapchain...\n");
+            fflush(stdout);
+
             MoSwapChainCreateInfo info = {};
             info.surface = surface;
             info.surfaceFormat = surfaceFormat;
             info.extent = {(uint32_t)width, (uint32_t)height};
             info.vsync = VK_TRUE;
             info.pCheckVkResultFn = moVkCheckResult;
+
+            printf("[cube_passthrough] Calling moCreateSwapChain...\n");
+            fflush(stdout);
+
             moCreateSwapChain(&info, &swapChain);
+
+            printf("[cube_passthrough] SwapChain created: %p\n", (void*)swapChain);
+            fflush(stdout);
         }
     }
+
+    printf("[cube_passthrough] About to create pipeline layout...\n");
+    fflush(stdout);
 
     MoPipelineLayout pipelineLayout;
     moCreatePipelineLayout(&pipelineLayout);
 
+    printf("[cube_passthrough] Pipeline layout created: %p\n", (void*)pipelineLayout);
+    fflush(stdout);
+
     // Passthrough
+    printf("[cube_passthrough] About to create pipeline...\n");
+    fflush(stdout);
+
     VkPipeline passthroughPipeline;
     moCreatePipeline(swapChain->renderPass, pipelineLayout->pipelineLayout, "passthrough.glsl", &passthroughPipeline, MO_PIPELINE_FEATURE_NONE);
+
+    printf("[cube_passthrough] Pipeline created: %p\n", (void*)passthroughPipeline);
+    fflush(stdout);
+
+    printf("[cube_passthrough] About to create demo cube...\n");
+    fflush(stdout);
 
     MoMesh cubeMesh;
     moCreateDemoCube(&cubeMesh, float3(0.5,0.5,0.5));
 
+    printf("[cube_passthrough] Demo cube created: %p\n", (void*)cubeMesh);
+    fflush(stdout);
+
+    printf("[cube_passthrough] About to enter main loop\n");
+    fflush(stdout);
+
     // Main loop
     while (!glfwWindowShouldClose(window))
     {
+        printf("[cube_passthrough] Main loop iteration starting\n");
+        fflush(stdout);
+
         glfwPollEvents();
+
+        printf("[cube_passthrough] About to begin swapchain\n");
+        fflush(stdout);
 
         // Frame begin
         MoCommandBuffer currentCommandBuffer;
         VkSemaphore imageAcquiredSemaphore;
         moBeginSwapChain(swapChain, &currentCommandBuffer, &imageAcquiredSemaphore);
+
+        printf("[cube_passthrough] Swapchain begun\n");
+        fflush(stdout);
+
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+
+        printf("[cube_passthrough] Render pass begun\n");
+        fflush(stdout);
+
+        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
+
+        printf("[cube_passthrough] Pipeline bound\n");
+        fflush(stdout);
+
         moDrawMesh(currentCommandBuffer.buffer, cubeMesh);
 
+        printf("[cube_passthrough] Mesh drawn\n");
+        fflush(stdout);
+
         // Frame end
+        printf("[cube_passthrough] About to end swapchain\n");
+        fflush(stdout);
+
         VkResult err = moEndSwapChain(swapChain, &imageAcquiredSemaphore);
+
+        printf("[cube_passthrough] Swapchain ended, err=%d\n", err);
+        fflush(stdout);
         if (err == VK_ERROR_OUT_OF_DATE_KHR)
         {
             int width = 0, height = 0;

--- a/examples/material_viewer/main.cpp
+++ b/examples/material_viewer/main.cpp
@@ -18,7 +18,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 
@@ -29,7 +29,7 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -239,7 +239,7 @@ int main(int argc, char** argv)
             uni.camera = camera.position;
             moUploadBuffer(pipelineLayout->uniformBuffer[swapChain->frameIndex], sizeof(MoUniform), &uni);
         }
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;

--- a/examples/teapot_blur/main.cpp
+++ b/examples/teapot_blur/main.cpp
@@ -14,10 +14,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
             uni.camera = camera.position;
             moUploadBuffer(pipelineLayout->uniformBuffer[swapChain->frameIndex], sizeof(MoUniform), &uni);
         }
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moBindRenderbuffer(currentCommandBuffer.buffer, renderBuffer, pipelineLayout->pipelineLayout, swapChain->frameIndex);
         if (scene)
         {

--- a/examples/teapot_readback/main.cpp
+++ b/examples/teapot_readback/main.cpp
@@ -12,14 +12,14 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 #include <vector>
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 

--- a/examples/teapot_unwrap/main.cpp
+++ b/examples/teapot_unwrap/main.cpp
@@ -11,10 +11,10 @@
 #include "mo_pipeline_utils.h"
 #include "mo_swapchain.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
         VkSemaphore imageAcquiredSemaphore;
         moBeginSwapChain(swapChain, &currentCommandBuffer, &imageAcquiredSemaphore);
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moBindRenderbuffer(currentCommandBuffer.buffer, renderBuffer, pipelineLayout->pipelineLayout, swapChain->frameIndex);
 
         if (scene)

--- a/examples/teapot_uvrenderpass/main.cpp
+++ b/examples/teapot_uvrenderpass/main.cpp
@@ -16,10 +16,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
                 VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                 vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
             }
-            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
             if (scene)
             {
                 MoPushConstant pmv = {};
@@ -353,7 +353,7 @@ int main(int argc, char** argv)
                     VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                     vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
                 }
-                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
                 if (scene)
                 {
                     MoPushConstant pmv = {};
@@ -382,7 +382,7 @@ int main(int argc, char** argv)
         }
 
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -390,7 +390,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         if (scene)
         {
             MoPushConstant pmv = {};

--- a/examples/teapot_viewer/main.cpp
+++ b/examples/teapot_viewer/main.cpp
@@ -14,10 +14,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -181,7 +181,7 @@ int main(int argc, char** argv)
             uni.camera = camera.position;
             moUploadBuffer(pipelineLayout->uniformBuffer[swapChain->frameIndex], sizeof(MoUniform), &uni);
         }
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         if (scene)
         {
             MoPushConstant pmv = {};

--- a/mo_device.cpp
+++ b/mo_device.cpp
@@ -24,7 +24,7 @@ void moCreateInstance(MoInstanceCreateInfo *pCreateInfo, VkInstance *pInstance)
         if (pCreateInfo->debugReport)
         {
             // Enabling multiple validation layers grouped as LunarG standard validation
-            const char* layers[] = { "VK_LAYER_LUNARG_standard_validation" };
+            const char* layers[] = { "VK_LAYER_KHRONOS_validation" };
             create_info.enabledLayerCount = 1;
             create_info.ppEnabledLayerNames = layers;
 

--- a/mo_node.cpp
+++ b/mo_node.cpp
@@ -5,14 +5,14 @@
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-namespace std { namespace filesystem = experimental::filesystem; }
 using namespace linalg;
 using namespace linalg::aliases;
+using namespace std::filesystem;
 
 void moCreateNode(const aiScene* aScene, MoScene scene, aiNode* aNode, MoNode* pNode)
 {
@@ -88,10 +88,10 @@ void moCreateScene(MoCommandBuffer commandBuffer, const char *filename, MoScene*
              {aiTextureType_NORMALS, &info.textureNormal}};
             for (auto mapping : textureMappings)
             {
-                aiString path;
-                if (AI_SUCCESS == material->GetTexture(mapping.first, 0, &path))
+                aiString texPath;
+                if (AI_SUCCESS == material->GetTexture(mapping.first, 0, &texPath))
                 {
-                    std::filesystem::path filename = parentdirectory / path.C_Str();
+                    std::filesystem::path filename = parentdirectory / texPath.C_Str();
                     if (std::filesystem::exists(filename))
                     {
                         int x, y, n;

--- a/mo_pipeline_utils.cpp
+++ b/mo_pipeline_utils.cpp
@@ -1,29 +1,36 @@
 #include "mo_pipeline_utils.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 
 void moCreatePipeline(VkRenderPass renderPass, VkPipelineLayout pipelineLayout, const char* glslFilename, VkPipeline *pPipeline, MoPipelineCreateFlags flags)
 {
+    // Load shaders into vectors BEFORE creating MoPipelineCreateInfo that will reference them
+    std::vector<char> mo_phong_shader_vert_spv;
+    std::vector<char> mo_phong_shader_frag_spv;
+
+    {
+        path glslFilepath(glslFilename);
+        path vertPath = glslFilepath;
+        vertPath.replace_extension("vert.spv");
+        std::ifstream fileStream(vertPath, std::ifstream::binary);
+        mo_phong_shader_vert_spv = std::vector<char>((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>());
+    }
+    {
+        path glslFilepath(glslFilename);
+        path fragPath = glslFilepath;
+        fragPath.replace_extension("frag.spv");
+        std::ifstream fileStream(fragPath, std::ifstream::binary);
+        mo_phong_shader_frag_spv = std::vector<char>((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>());
+    }
+
     MoPipelineCreateInfo info = {};
     info.flags = flags;
     info.pipelineLayout = pipelineLayout;
     info.renderPass = renderPass;
-    std::vector<char> mo_phong_shader_vert_spv;
-    {
-        std::filesystem::path glslFilepath(glslFilename);
-        std::ifstream fileStream(glslFilepath.replace_extension("vert.spv"), std::ifstream::binary);
-        mo_phong_shader_vert_spv = std::vector<char>((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>());
-    }
-    std::vector<char> mo_phong_shader_frag_spv;
-    {
-        std::filesystem::path glslFilepath(glslFilename);
-        std::ifstream fileStream(glslFilepath.replace_extension("frag.spv"), std::ifstream::binary);
-        mo_phong_shader_frag_spv = std::vector<char>((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>());
-    }
     info.pVertexShader = (std::uint32_t*)mo_phong_shader_vert_spv.data();
     info.vertexShaderSize = mo_phong_shader_vert_spv.size();
     info.pFragmentShader = (std::uint32_t*)mo_phong_shader_frag_spv.data();

--- a/mo_swapchain.cpp
+++ b/mo_swapchain.cpp
@@ -50,7 +50,8 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
     if (pCreateInfo->offscreen)
     {
         swapChain->extent = pCreateInfo->extent;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        swapChain->imageCount = MO_FRAME_COUNT;  // Offscreen mode uses MO_FRAME_COUNT images
+        for (uint32_t i = 0; i < MO_FRAME_COUNT; ++i)
         {
             {
                 VkImageCreateInfo info = {};
@@ -119,11 +120,17 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
         uint32_t backBufferCount = 0;
         err = vkGetSwapchainImagesKHR(g_Device->device, swapChain->swapChainKHR, &backBufferCount, NULL);
         pCreateInfo->pCheckVkResultFn(err);
-        VkImage backBuffer[MO_FRAME_COUNT] = {};
+
+        // Support up to MO_SWAPCHAIN_IMAGE_COUNT images
+        VkImage backBuffer[MO_SWAPCHAIN_IMAGE_COUNT] = {};
+        if (backBufferCount > MO_SWAPCHAIN_IMAGE_COUNT) {
+            backBufferCount = MO_SWAPCHAIN_IMAGE_COUNT;
+        }
         err = vkGetSwapchainImagesKHR(g_Device->device, swapChain->swapChainKHR, &backBufferCount, backBuffer);
         pCreateInfo->pCheckVkResultFn(err);
 
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        swapChain->imageCount = backBufferCount;
+        for (uint32_t i = 0; i < backBufferCount; ++i)
         {
             swapChain->images[i].back = backBuffer[i];
         }
@@ -188,11 +195,14 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
         info.components.a = VK_COMPONENT_SWIZZLE_A;
         VkImageSubresourceRange image_range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
         info.subresourceRange = image_range;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount && i < MO_SWAPCHAIN_IMAGE_COUNT; ++i)
         {
-            info.image = swapChain->images[i].back;
-            err = vkCreateImageView(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].view);
-            pCreateInfo->pCheckVkResultFn(err);
+            if (swapChain->images[i].back != VK_NULL_HANDLE)
+            {
+                info.image = swapChain->images[i].back;
+                err = vkCreateImageView(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].view);
+                pCreateInfo->pCheckVkResultFn(err);
+            }
         }
     }
 
@@ -209,11 +219,14 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
         info.width = swapChain->extent.width;
         info.height = swapChain->extent.height;
         info.layers = 1;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount && i < MO_SWAPCHAIN_IMAGE_COUNT; ++i)
         {
-            attachment[0] = swapChain->images[i].view;
-            err = vkCreateFramebuffer(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].front);
-            pCreateInfo->pCheckVkResultFn(err);
+            if (swapChain->images[i].view != VK_NULL_HANDLE)
+            {
+                attachment[0] = swapChain->images[i].view;
+                err = vkCreateFramebuffer(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].front);
+                pCreateInfo->pCheckVkResultFn(err);
+            }
         }
     }
 
@@ -228,14 +241,18 @@ void moRecreateSwapChain(MoSwapChainRecreateInfo *pCreateInfo, MoSwapChain swapC
     g_Device->pCheckVkResultFn(err);
 
     moDeleteBuffer(swapChain->depthBuffer);
-    for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+    for (uint32_t i = 0; i < swapChain->imageCount && i < MO_SWAPCHAIN_IMAGE_COUNT; ++i)
     {
-        vkDestroyImageView(g_Device->device, swapChain->images[i].view, VK_NULL_HANDLE);
-        vkDestroyFramebuffer(g_Device->device, swapChain->images[i].front, VK_NULL_HANDLE);
+        if (swapChain->images[i].view != VK_NULL_HANDLE)
+            vkDestroyImageView(g_Device->device, swapChain->images[i].view, VK_NULL_HANDLE);
+        if (swapChain->images[i].front != VK_NULL_HANDLE)
+            vkDestroyFramebuffer(g_Device->device, swapChain->images[i].front, VK_NULL_HANDLE);
         if (swapChain->swapChainKHR == VK_NULL_HANDLE) //offscreen
         {
-            vkFreeMemory(g_Device->device, swapChain->images[i].memory, VK_NULL_HANDLE);
-            vkDestroyImage(g_Device->device, swapChain->images[i].back, VK_NULL_HANDLE);
+            if (swapChain->images[i].memory != VK_NULL_HANDLE)
+                vkFreeMemory(g_Device->device, swapChain->images[i].memory, VK_NULL_HANDLE);
+            if (swapChain->images[i].back != VK_NULL_HANDLE)
+                vkDestroyImage(g_Device->device, swapChain->images[i].back, VK_NULL_HANDLE);
         }
     }
     if (swapChain->renderPass)
@@ -483,7 +500,8 @@ VkResult moEndSwapChain(MoSwapChain swapChain, VkSemaphore *pImageAcquiredSemaph
 {
     VkResult err;
 
-    MoCommandBuffer currentCommandBuffer = swapChain->frames[swapChain->frameIndex];
+    // Use currentFrame (0, 1, 0, 1, ...) not frameIndex (0-4) for accessing frames array
+    MoCommandBuffer currentCommandBuffer = swapChain->frames[swapChain->currentFrame];
 
     vkCmdEndRenderPass(currentCommandBuffer.buffer);
 
@@ -562,14 +580,18 @@ void moDestroySwapChain(MoSwapChain swapChain)
     }
 
     moDeleteBuffer(swapChain->depthBuffer);
-    for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+    for (uint32_t i = 0; i < swapChain->imageCount && i < MO_SWAPCHAIN_IMAGE_COUNT; ++i)
     {
-        vkDestroyImageView(g_Device->device, swapChain->images[i].view, VK_NULL_HANDLE);
-        vkDestroyFramebuffer(g_Device->device, swapChain->images[i].front, VK_NULL_HANDLE);
+        if (swapChain->images[i].view != VK_NULL_HANDLE)
+            vkDestroyImageView(g_Device->device, swapChain->images[i].view, VK_NULL_HANDLE);
+        if (swapChain->images[i].front != VK_NULL_HANDLE)
+            vkDestroyFramebuffer(g_Device->device, swapChain->images[i].front, VK_NULL_HANDLE);
         if (swapChain->swapChainKHR == VK_NULL_HANDLE) //offscreen
         {
-            vkFreeMemory(g_Device->device, swapChain->images[i].memory, VK_NULL_HANDLE);
-            vkDestroyImage(g_Device->device, swapChain->images[i].back, VK_NULL_HANDLE);
+            if (swapChain->images[i].memory != VK_NULL_HANDLE)
+                vkFreeMemory(g_Device->device, swapChain->images[i].memory, VK_NULL_HANDLE);
+            if (swapChain->images[i].back != VK_NULL_HANDLE)
+                vkDestroyImage(g_Device->device, swapChain->images[i].back, VK_NULL_HANDLE);
         }
     }
     vkDestroyRenderPass(g_Device->device, swapChain->renderPass, VK_NULL_HANDLE);

--- a/mo_swapchain.h
+++ b/mo_swapchain.h
@@ -9,6 +9,7 @@
 #include <linalg.h>
 
 #define MO_FRAME_COUNT 2
+#define MO_SWAPCHAIN_IMAGE_COUNT 8  // Support up to 8 swapchain images
 
 typedef struct MoSwapChainCreateInfo {
     VkSurfaceKHR                 surface;
@@ -29,9 +30,11 @@ typedef struct MoSwapChainRecreateInfo {
 } MoSwapChainRecreateInfo;
 
 typedef struct MoSwapChain_T {
-    MoSwapBuffer    images[MO_FRAME_COUNT];
-    MoCommandBuffer frames[MO_FRAME_COUNT];
-    uint32_t        frameIndex;
+    MoSwapBuffer    images[MO_SWAPCHAIN_IMAGE_COUNT];  // Array of swapchain images
+    MoCommandBuffer frames[MO_FRAME_COUNT];             // Command buffers for frame pipelining
+    uint32_t        frameIndex;                        // Current swapchain image index (from vkAcquireNextImageKHR)
+    uint32_t        currentFrame;                      // Our frame counter (0, 1, 0, 1, ...) for command buffers
+    uint32_t        imageCount;                        // Actual number of swapchain images
     MoImageBuffer   depthBuffer;
     VkSwapchainKHR  swapChainKHR;
     VkRenderPass    renderPass;


### PR DESCRIPTION
- Fix descriptor set array indexing: use currentFrame (0,1) instead of frameIndex (0-4) All example files were incorrectly indexing pipelineLayout->descriptorSet[] with swapChain->frameIndex which can be 0-4, while the array only has MO_FRAME_COUNT=2 elements. Changed to use currentFrame which cycles 0,1,0,1...

- Expand swapchain image array from 2 to 8 elements to handle variable image counts The driver can create 2-5 swapchain images, but code only allocated MO_FRAME_COUNT framebuffers. Added MO_SWAPCHAIN_IMAGE_COUNT=8 and imageCount field.

- Fix moEndSwapChain() to use currentFrame instead of frameIndex for frame selection The function was trying to access frames[frameIndex] when it should use frames[currentFrame] since frameIndex is the swapchain image index.

- Fix use-after-free in mo_pipeline_utils.cpp Moved std::vector declarations outside scope so shader data remains valid during moCreatePipeline() call.

- Migrate from deprecated experimental::filesystem to C++17 std::filesystem Updated CMakeLists.txt to require C++17 and updated all source files to use std::filesystem instead of std::experimental::filesystem.

- Fix ImGui dependencies in 3rdparty CMakeLists.txt Added glfw include path and linked glfw to imgui target.