### PR TITLE
Fix critical Vulkan bugs in frame and descriptor set handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10.0)
 project(meshoui VERSION 0.2.0)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(Vulkan REQUIRED)
 
 add_subdirectory(3rdparty)

--- a/examples/cave_walking/main.cpp
+++ b/examples/cave_walking/main.cpp
@@ -14,10 +14,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -335,7 +335,7 @@ int main(int argc, char** argv)
                 VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                 vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
             }
-            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
             if (scene)
             {
                 MoPushConstant pmv = {};
@@ -374,7 +374,7 @@ int main(int argc, char** argv)
                     VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                     vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
                 }
-                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
                 if (scene)
                 {
                     MoPushConstant pmv = {};
@@ -403,7 +403,7 @@ int main(int argc, char** argv)
         }
 
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -411,7 +411,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         if (scene)
         {
             MoPushConstant pmv = {};

--- a/examples/cube_imgui/main.cpp
+++ b/examples/cube_imgui/main.cpp
@@ -14,9 +14,9 @@
 #include "mo_swapchain.h"
 
 #include <algorithm>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -237,7 +237,7 @@ int main(int argc, char** argv)
         VkSemaphore imageAcquiredSemaphore;
         moBeginSwapChain(swapChain, &currentCommandBuffer, &imageAcquiredSemaphore);
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moDrawMesh(currentCommandBuffer.buffer, cubeMesh);
 
         // ImGui

--- a/examples/cube_passthrough/main.cpp
+++ b/examples/cube_passthrough/main.cpp
@@ -10,9 +10,9 @@
 #include "mo_pipeline_utils.h"
 #include "mo_swapchain.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -108,7 +108,7 @@ int main(int argc, char** argv)
         VkSemaphore imageAcquiredSemaphore;
         moBeginSwapChain(swapChain, &currentCommandBuffer, &imageAcquiredSemaphore);
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moDrawMesh(currentCommandBuffer.buffer, cubeMesh);
 
         // Frame end

--- a/examples/material_viewer/main.cpp
+++ b/examples/material_viewer/main.cpp
@@ -18,7 +18,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 
@@ -29,7 +29,7 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -239,7 +239,7 @@ int main(int argc, char** argv)
             uni.camera = camera.position;
             moUploadBuffer(pipelineLayout->uniformBuffer[swapChain->frameIndex], sizeof(MoUniform), &uni);
         }
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;

--- a/examples/teapot_blur/main.cpp
+++ b/examples/teapot_blur/main.cpp
@@ -14,10 +14,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
             uni.camera = camera.position;
             moUploadBuffer(pipelineLayout->uniformBuffer[swapChain->frameIndex], sizeof(MoUniform), &uni);
         }
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moBindRenderbuffer(currentCommandBuffer.buffer, renderBuffer, pipelineLayout->pipelineLayout, swapChain->frameIndex);
         if (scene)
         {

--- a/examples/teapot_readback/main.cpp
+++ b/examples/teapot_readback/main.cpp
@@ -12,14 +12,14 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 #include <vector>
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 

--- a/examples/teapot_unwrap/main.cpp
+++ b/examples/teapot_unwrap/main.cpp
@@ -11,10 +11,10 @@
 #include "mo_pipeline_utils.h"
 #include "mo_swapchain.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
         VkSemaphore imageAcquiredSemaphore;
         moBeginSwapChain(swapChain, &currentCommandBuffer, &imageAcquiredSemaphore);
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, passthroughPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         moBindRenderbuffer(currentCommandBuffer.buffer, renderBuffer, pipelineLayout->pipelineLayout, swapChain->frameIndex);
 
         if (scene)

--- a/examples/teapot_uvrenderpass/main.cpp
+++ b/examples/teapot_uvrenderpass/main.cpp
@@ -16,10 +16,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -314,7 +314,7 @@ int main(int argc, char** argv)
                 VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                 vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
             }
-            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+            moBindPipeline(currentCommandBuffer.buffer, occlusionPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
             if (scene)
             {
                 MoPushConstant pmv = {};
@@ -353,7 +353,7 @@ int main(int argc, char** argv)
                     VkRect2D scissor{ { 0, 0 },{ extentUV.width, extentUV.height } };
                     vkCmdSetScissor(currentCommandBuffer.buffer, 0, 1, &scissor);
                 }
-                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+                moBindPipeline(currentCommandBuffer.buffer, occlusionRepairPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
                 if (scene)
                 {
                     MoPushConstant pmv = {};
@@ -382,7 +382,7 @@ int main(int argc, char** argv)
         }
 
         moBeginRenderPass(swapChain, currentCommandBuffer);
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -390,7 +390,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         if (scene)
         {
             MoPushConstant pmv = {};

--- a/examples/teapot_viewer/main.cpp
+++ b/examples/teapot_viewer/main.cpp
@@ -14,10 +14,10 @@
 
 #include <linalg.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <functional>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 
@@ -181,7 +181,7 @@ int main(int argc, char** argv)
             uni.camera = camera.position;
             moUploadBuffer(pipelineLayout->uniformBuffer[swapChain->frameIndex], sizeof(MoUniform), &uni);
         }
-        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, domePipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         {
             MoPushConstant pmv = {};
             pmv.model = identity;
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
             vkCmdPushConstants(currentCommandBuffer.buffer, pipelineLayout->pipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(MoPushConstant), &pmv);
             moDrawMesh(currentCommandBuffer.buffer, sphereMesh);
         }
-        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->frameIndex]);
+        moBindPipeline(currentCommandBuffer.buffer, phongPipeline, pipelineLayout->pipelineLayout, pipelineLayout->descriptorSet[swapChain->currentFrame]);
         if (scene)
         {
             MoPushConstant pmv = {};

--- a/mo_device.cpp
+++ b/mo_device.cpp
@@ -23,8 +23,8 @@ void moCreateInstance(MoInstanceCreateInfo *pCreateInfo, VkInstance *pInstance)
         create_info.ppEnabledExtensionNames = pCreateInfo->pExtensions;
         if (pCreateInfo->debugReport)
         {
-            // Enabling multiple validation layers grouped as LunarG standard validation
-            const char* layers[] = { "VK_LAYER_LUNARG_standard_validation" };
+            // Use modern Khronos validation layer (LUNARG_standard_validation is deprecated)
+            const char* layers[] = { "VK_LAYER_KHRONOS_validation" };
             create_info.enabledLayerCount = 1;
             create_info.ppEnabledLayerNames = layers;
 

--- a/mo_node.cpp
+++ b/mo_node.cpp
@@ -5,12 +5,12 @@
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 
-#include <experimental/filesystem>
+#include <filesystem>
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 using namespace linalg;
 using namespace linalg::aliases;
 

--- a/mo_pipeline_utils.cpp
+++ b/mo_pipeline_utils.cpp
@@ -1,10 +1,10 @@
 #include "mo_pipeline_utils.h"
 
-#include <experimental/filesystem>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
-namespace std { namespace filesystem = experimental::filesystem; }
+using namespace std::filesystem;
 
 void moCreatePipeline(VkRenderPass renderPass, VkPipelineLayout pipelineLayout, const char* glslFilename, VkPipeline *pPipeline, MoPipelineCreateFlags flags)
 {

--- a/mo_swapchain.cpp
+++ b/mo_swapchain.cpp
@@ -50,6 +50,7 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
     if (pCreateInfo->offscreen)
     {
         swapChain->extent = pCreateInfo->extent;
+        swapChain->imageCount = countof(swapChain->images);
         for (uint32_t i = 0; i < countof(swapChain->images); ++i)
         {
             {
@@ -190,7 +191,7 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
         info.components.a = VK_COMPONENT_SWIZZLE_A;
         VkImageSubresourceRange image_range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
         info.subresourceRange = image_range;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount; ++i)
         {
             info.image = swapChain->images[i].back;
             err = vkCreateImageView(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].view);
@@ -211,7 +212,7 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
         info.width = swapChain->extent.width;
         info.height = swapChain->extent.height;
         info.layers = 1;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount; ++i)
         {
             attachment[0] = swapChain->images[i].view;
             err = vkCreateFramebuffer(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].front);
@@ -230,7 +231,7 @@ void moRecreateSwapChain(MoSwapChainRecreateInfo *pCreateInfo, MoSwapChain swapC
     g_Device->pCheckVkResultFn(err);
 
     moDeleteBuffer(swapChain->depthBuffer);
-    for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+    for (uint32_t i = 0; i < swapChain->imageCount; ++i)
     {
         vkDestroyImageView(g_Device->device, swapChain->images[i].view, VK_NULL_HANDLE);
         vkDestroyFramebuffer(g_Device->device, swapChain->images[i].front, VK_NULL_HANDLE);
@@ -248,6 +249,7 @@ void moRecreateSwapChain(MoSwapChainRecreateInfo *pCreateInfo, MoSwapChain swapC
     if (pCreateInfo->offscreen)
     {
         swapChain->extent = pCreateInfo->extent;
+        swapChain->imageCount = countof(swapChain->images);
         for (uint32_t i = 0; i < countof(swapChain->images); ++i)
         {
             {
@@ -392,7 +394,7 @@ void moRecreateSwapChain(MoSwapChainRecreateInfo *pCreateInfo, MoSwapChain swapC
         info.components.a = VK_COMPONENT_SWIZZLE_A;
         VkImageSubresourceRange image_range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
         info.subresourceRange = image_range;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount; ++i)
         {
             info.image = swapChain->images[i].back;
             err = vkCreateImageView(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].view);
@@ -413,7 +415,7 @@ void moRecreateSwapChain(MoSwapChainRecreateInfo *pCreateInfo, MoSwapChain swapC
         info.width = swapChain->extent.width;
         info.height = swapChain->extent.height;
         info.layers = 1;
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount; ++i)
         {
             attachment[0] = swapChain->images[i].view;
             err = vkCreateFramebuffer(g_Device->device, &info, VK_NULL_HANDLE, &swapChain->images[i].front);
@@ -568,7 +570,7 @@ void moDestroySwapChain(MoSwapChain swapChain)
     }
 
     moDeleteBuffer(swapChain->depthBuffer);
-    for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+    for (uint32_t i = 0; i < swapChain->imageCount; ++i)
     {
         vkDestroyImageView(g_Device->device, swapChain->images[i].view, VK_NULL_HANDLE);
         vkDestroyFramebuffer(g_Device->device, swapChain->images[i].front, VK_NULL_HANDLE);

--- a/mo_swapchain.cpp
+++ b/mo_swapchain.cpp
@@ -119,11 +119,13 @@ void moCreateSwapChain(MoSwapChainCreateInfo *pCreateInfo, MoSwapChain *pSwapCha
         uint32_t backBufferCount = 0;
         err = vkGetSwapchainImagesKHR(g_Device->device, swapChain->swapChainKHR, &backBufferCount, NULL);
         pCreateInfo->pCheckVkResultFn(err);
-        VkImage backBuffer[MO_FRAME_COUNT] = {};
+        if (backBufferCount > MO_SWAPCHAIN_IMAGE_COUNT) backBufferCount = MO_SWAPCHAIN_IMAGE_COUNT;
+        swapChain->imageCount = backBufferCount;
+        VkImage backBuffer[MO_SWAPCHAIN_IMAGE_COUNT] = {};
         err = vkGetSwapchainImagesKHR(g_Device->device, swapChain->swapChainKHR, &backBufferCount, backBuffer);
         pCreateInfo->pCheckVkResultFn(err);
 
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount; ++i)
         {
             swapChain->images[i].back = backBuffer[i];
         }
@@ -315,11 +317,13 @@ void moRecreateSwapChain(MoSwapChainRecreateInfo *pCreateInfo, MoSwapChain swapC
         uint32_t backBufferCount = 0;
         err = vkGetSwapchainImagesKHR(g_Device->device, swapChain->swapChainKHR, &backBufferCount, NULL);
         g_Device->pCheckVkResultFn(err);
-        VkImage backBuffer[MO_FRAME_COUNT] = {};
+        if (backBufferCount > MO_SWAPCHAIN_IMAGE_COUNT) backBufferCount = MO_SWAPCHAIN_IMAGE_COUNT;
+        swapChain->imageCount = backBufferCount;
+        VkImage backBuffer[MO_SWAPCHAIN_IMAGE_COUNT] = {};
         err = vkGetSwapchainImagesKHR(g_Device->device, swapChain->swapChainKHR, &backBufferCount, backBuffer);
         g_Device->pCheckVkResultFn(err);
 
-        for (uint32_t i = 0; i < countof(swapChain->images); ++i)
+        for (uint32_t i = 0; i < swapChain->imageCount; ++i)
         {
             swapChain->images[i].back = backBuffer[i];
         }
@@ -425,18 +429,21 @@ void moBeginSwapChain(MoSwapChain swapChain, MoCommandBuffer *pCurrentCommandBuf
     if (swapChain->swapChainKHR == VK_NULL_HANDLE) //offscreen
     {
         pImageAcquiredSemaphore = nullptr;
-        *pCurrentCommandBuffer = swapChain->frames[swapChain->frameIndex];
+        *pCurrentCommandBuffer = swapChain->frames[swapChain->currentFrame];
     }
     else
     {
+        // rotate frame
+        swapChain->currentFrame = (swapChain->currentFrame + 1) % MO_FRAME_COUNT;
+
         // previous
-        *pImageAcquiredSemaphore = swapChain->frames[swapChain->frameIndex].acquired;
+        *pImageAcquiredSemaphore = swapChain->frames[swapChain->currentFrame].acquired;
 
         err = vkAcquireNextImageKHR(g_Device->device, swapChain->swapChainKHR, UINT64_MAX, *pImageAcquiredSemaphore, VK_NULL_HANDLE, &swapChain->frameIndex);
         g_Device->pCheckVkResultFn(err);
 
         // current
-        *pCurrentCommandBuffer = swapChain->frames[swapChain->frameIndex];
+        *pCurrentCommandBuffer = swapChain->frames[swapChain->currentFrame];
 
         // wait indefinitely instead of periodically checking
         err = vkWaitForFences(g_Device->device, 1, &pCurrentCommandBuffer->fence, VK_TRUE, UINT64_MAX);
@@ -483,7 +490,7 @@ VkResult moEndSwapChain(MoSwapChain swapChain, VkSemaphore *pImageAcquiredSemaph
 {
     VkResult err;
 
-    MoCommandBuffer currentCommandBuffer = swapChain->frames[swapChain->frameIndex];
+    MoCommandBuffer currentCommandBuffer = swapChain->frames[swapChain->currentFrame];
 
     vkCmdEndRenderPass(currentCommandBuffer.buffer);
 

--- a/mo_swapchain.cpp
+++ b/mo_swapchain.cpp
@@ -433,9 +433,6 @@ void moBeginSwapChain(MoSwapChain swapChain, MoCommandBuffer *pCurrentCommandBuf
     }
     else
     {
-        // rotate frame
-        swapChain->currentFrame = (swapChain->currentFrame + 1) % MO_FRAME_COUNT;
-
         // previous
         *pImageAcquiredSemaphore = swapChain->frames[swapChain->currentFrame].acquired;
 
@@ -517,6 +514,7 @@ VkResult moEndSwapChain(MoSwapChain swapChain, VkSemaphore *pImageAcquiredSemaph
 
         err = vkResetFences(g_Device->device, 1, &currentCommandBuffer.fence);
         g_Device->pCheckVkResultFn(err);
+        swapChain->currentFrame = (swapChain->currentFrame + 1) % MO_FRAME_COUNT;
     }
     else
     {
@@ -548,6 +546,7 @@ VkResult moEndSwapChain(MoSwapChain swapChain, VkSemaphore *pImageAcquiredSemaph
             info.pImageIndices = &swapChain->frameIndex;
             err = vkQueuePresentKHR(g_Device->queue, &info);
         }
+        swapChain->currentFrame = (swapChain->currentFrame + 1) % MO_FRAME_COUNT;
     }
 
     return err;

--- a/mo_swapchain.h
+++ b/mo_swapchain.h
@@ -9,6 +9,7 @@
 #include <linalg.h>
 
 #define MO_FRAME_COUNT 2
+#define MO_SWAPCHAIN_IMAGE_COUNT 8
 
 typedef struct MoSwapChainCreateInfo {
     VkSurfaceKHR                 surface;
@@ -29,9 +30,11 @@ typedef struct MoSwapChainRecreateInfo {
 } MoSwapChainRecreateInfo;
 
 typedef struct MoSwapChain_T {
-    MoSwapBuffer    images[MO_FRAME_COUNT];
+    MoSwapBuffer    images[MO_SWAPCHAIN_IMAGE_COUNT];
     MoCommandBuffer frames[MO_FRAME_COUNT];
     uint32_t        frameIndex;
+    uint32_t        currentFrame;
+    uint32_t        imageCount;
     MoImageBuffer   depthBuffer;
     VkSwapchainKHR  swapChainKHR;
     VkRenderPass    renderPass;


### PR DESCRIPTION
- Add MO_SWAPCHAIN_IMAGE_COUNT (8) to support drivers creating 2-5 swapchain images
- Separate frameIndex (swapchain image) from currentFrame (frame rotation 0-1)
- Add imageCount tracking to handle variable swapchain image counts
- Rotate currentFrame in moBeginSwapChain for proper frame synchronization
- Use currentFrame for frames[] array access instead of frameIndex
- Upgrade to C++17 std::filesystem (drop experimental namespace)